### PR TITLE
removed @dev from friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "friendsofphp/php-cs-fixer": "~2.12@dev"
+        "friendsofphp/php-cs-fixer": "^2.12"
     },
     "require-dev": {
-        "phpspec/phpspec": "^3.4",
-        "twig/twig": "^1.35",
-        "webmozart/assert": "^1.3"
+        "phpspec/phpspec": "^3.4.0",
+        "twig/twig": "^1.35.0",
+        "webmozart/assert": "^1.3.0"
     },
     "autoload": {
         "psr-4": { "PedroTroller\\CS\\": "src/PedroTroller/CS/" }
@@ -27,6 +27,8 @@
             "dev-master": "2.x-dev"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "tests": [
             "tests\\Runner::run",


### PR DESCRIPTION
added [minimum-stability](https://getcomposer.org/doc/04-schema.md#minimum-stability) and [prefer-stable](https://getcomposer.org/doc/04-schema.md#prefer-stable) to install always if possible stable packages versions  