### PR TITLE
fix compatibility with php-cs-fixer 3.59.3

### DIFF
--- a/src/PedroTroller/CS/Fixer/Behat/OrderBehatStepsFixer.php
+++ b/src/PedroTroller/CS/Fixer/Behat/OrderBehatStepsFixer.php
@@ -8,6 +8,7 @@ use PedroTroller\CS\Fixer\AbstractOrderedClassElementsFixer;
 use PedroTroller\CS\Fixer\Priority;
 use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
@@ -15,6 +16,8 @@ use PhpCsFixer\Tokenizer\Tokens;
 
 final class OrderBehatStepsFixer extends AbstractOrderedClassElementsFixer implements ConfigurableFixerInterface
 {
+    use ConfigurableFixerTrait;
+
     public const ANNOTATION_PRIORITIES = [
         '@BeforeSuite',
         '@AfterSuite',
@@ -126,7 +129,7 @@ final class OrderBehatStepsFixer extends AbstractOrderedClassElementsFixer imple
         return 'Step definition methods in Behat contexts MUST BE ordered by annotation and method name.';
     }
 
-    public function getConfigurationDefinition(): FixerConfigurationResolverInterface
+    public function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('instanceof', 'Parent class or interface of your behat context classes.'))

--- a/src/PedroTroller/CS/Fixer/CodingStyle/ForbiddenFunctionsFixer.php
+++ b/src/PedroTroller/CS/Fixer/CodingStyle/ForbiddenFunctionsFixer.php
@@ -6,6 +6,7 @@ namespace PedroTroller\CS\Fixer\CodingStyle;
 
 use PedroTroller\CS\Fixer\AbstractFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
@@ -15,6 +16,8 @@ use SplFileInfo;
 
 final class ForbiddenFunctionsFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
+    use ConfigurableFixerTrait;
+
     public function getSampleCode(): string
     {
         return <<<'PHP'
@@ -53,7 +56,7 @@ final class ForbiddenFunctionsFixer extends AbstractFixer implements Configurabl
         return 'Prohibited functions MUST BE commented on as prohibited';
     }
 
-    public function getConfigurationDefinition(): FixerConfigurationResolverInterface
+    public function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('functions', 'The function names to be marked how prohibited'))

--- a/src/PedroTroller/CS/Fixer/CodingStyle/LineBreakBetweenMethodArgumentsFixer.php
+++ b/src/PedroTroller/CS/Fixer/CodingStyle/LineBreakBetweenMethodArgumentsFixer.php
@@ -8,6 +8,7 @@ use PedroTroller\CS\Fixer\AbstractFixer;
 use PedroTroller\CS\Fixer\Priority;
 use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
 use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
@@ -19,6 +20,8 @@ use SplFileInfo;
 
 final class LineBreakBetweenMethodArgumentsFixer extends AbstractFixer implements ConfigurableFixerInterface, WhitespacesAwareFixerInterface
 {
+    use ConfigurableFixerTrait;
+
     public const T_TYPEHINT_SEMI_COLON = 10025;
 
     public function getPriority(): int
@@ -81,7 +84,7 @@ final class LineBreakBetweenMethodArgumentsFixer extends AbstractFixer implement
             SPEC;
     }
 
-    public function getConfigurationDefinition(): FixerConfigurationResolverInterface
+    public function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('max-args', 'The maximum number of arguments allowed with splitting the arguments into several lines (use `false` to disable this feature)'))

--- a/src/PedroTroller/CS/Fixer/DoctrineMigrationsFixer.php
+++ b/src/PedroTroller/CS/Fixer/DoctrineMigrationsFixer.php
@@ -6,6 +6,7 @@ namespace PedroTroller\CS\Fixer;
 
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
 use PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
@@ -17,6 +18,8 @@ use SplFileInfo;
 
 final class DoctrineMigrationsFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
+    use ConfigurableFixerTrait;
+    
     /**
      * @var string[]
      */
@@ -100,7 +103,7 @@ final class DoctrineMigrationsFixer extends AbstractFixer implements Configurabl
         return Priority::before(ClassAttributesSeparationFixer::class, NoEmptyPhpdocFixer::class, NoExtraBlankLinesFixer::class);
     }
 
-    public function getConfigurationDefinition(): FixerConfigurationResolverInterface
+    public function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('instanceof', 'The parent class of which Doctrine migrations extend'))

--- a/src/PedroTroller/CS/Fixer/PhpspecFixer.php
+++ b/src/PedroTroller/CS/Fixer/PhpspecFixer.php
@@ -6,6 +6,7 @@ namespace PedroTroller\CS\Fixer;
 
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
 use PhpCsFixer\Fixer\FunctionNotation\StaticLambdaFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
@@ -17,6 +18,8 @@ use SplFileInfo;
 
 final class PhpspecFixer extends AbstractOrderedClassElementsFixer implements ConfigurableFixerInterface
 {
+    use ConfigurableFixerTrait;
+
     public function getSampleConfigurations(): array
     {
         return [
@@ -101,7 +104,7 @@ final class PhpspecFixer extends AbstractOrderedClassElementsFixer implements Co
         );
     }
 
-    public function getConfigurationDefinition(): FixerConfigurationResolverInterface
+    public function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('instanceof', 'Parent classes of your spec classes.'))


### PR DESCRIPTION
php-cs-fixer seems to have changed a bit in their configuration approach between 3.59.2 and 3.59.3.

I don't know if the BC break was meant to happen, or if the fixers in this package are just old and were still using deprecated ways.

Anyway, this seems to fix it.
