### PR TITLE
fix: improve handling of comments in line_break_between_method_arguments

### DIFF
--- a/src/PedroTroller/CS/Fixer/CodingStyle/LineBreakBetweenMethodArgumentsFixer.php
+++ b/src/PedroTroller/CS/Fixer/CodingStyle/LineBreakBetweenMethodArgumentsFixer.php
@@ -235,10 +235,20 @@ final class LineBreakBetweenMethodArgumentsFixer extends AbstractFixer implement
         $closeBraceIndex = $this->analyze($tokens)->getClosingParenthesis($openBraceIndex);
 
         foreach ($tokens->findGivenKind(T_WHITESPACE, $openBraceIndex, $closeBraceIndex) as $spaceIndex => $spaceToken) {
+            if ($tokens[$tokens->getPrevNonWhitespace($spaceIndex)]->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+                continue;
+            }
+
+            if ($tokens[$tokens->getNextNonWhitespace($spaceIndex)]->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+                continue;
+            }
+
             $tokens[$spaceIndex] = new Token([T_WHITESPACE, ' ']);
         }
 
-        $tokens->removeTrailingWhitespace($openBraceIndex);
+        if (!$tokens[$tokens->getNextNonWhitespace($openBraceIndex)]->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+            $tokens->removeTrailingWhitespace($openBraceIndex);
+        }
         $tokens->removeLeadingWhitespace($closeBraceIndex);
 
         $end = $tokens->getNextTokenOfKind($closeBraceIndex, [';', '{']);

--- a/tests/UseCase/LineBreakBetweenMethods/Regression/Case10.php
+++ b/tests/UseCase/LineBreakBetweenMethods/Regression/Case10.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\UseCase\LineBreakBetweenMethods\Regression;
+
+use PedroTroller\CS\Fixer\CodingStyle\LineBreakBetweenMethodArgumentsFixer;
+use tests\UseCase;
+
+/**
+ * https://github.com/PedroTroller/PhpCSFixer-Custom-Fixers/issues/208
+ * https://github.com/PedroTroller/PhpCSFixer-Custom-Fixers/issues/214.
+ */
+final class Case10 implements UseCase
+{
+    public function getFixers(): iterable
+    {
+        yield new LineBreakBetweenMethodArgumentsFixer();
+    }
+
+    public function getRawScript(): string
+    {
+        return <<<'PHP'
+            <?php
+
+            class Foo
+            {
+                public function __construct(
+                    // simple comment
+                    public ?string $simpleCommentAbove = null,
+                    // public string|null $commentedOutLine = null,
+                    public ?string $detailAndEdit = null,
+                    /**
+                     * @var list<string>
+                     */
+                    public array $groups = [])
+                {
+                }
+            }
+            PHP;
+    }
+
+    public function getExpectation(): string
+    {
+        return $this->getRawScript();
+    }
+
+    public function getMinSupportedPhpVersion(): int
+    {
+        return 80000;
+    }
+}


### PR DESCRIPTION
Addresses #208 and #214, plus another comment related use case fix (single line comment above parameter)